### PR TITLE
patch: migations config system

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -59,7 +59,7 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 # output_encoding = utf-8
 
 sqlalchemy.url = driver://user:pass@localhost/dbname
-
+app_config_path = configs/local.yaml
 
 [post_write_hooks]
 # post_write_hooks defines scripts or Python functions that are run

--- a/app/common/config/_yaml_source.py
+++ b/app/common/config/_yaml_source.py
@@ -44,7 +44,7 @@ class YamlConfigSettingsSource(PydanticBaseSettingsSource):
         path = Path(yaml_file)
 
         if not path.exists():
-            raise FileNotFoundError(f"Could not open yaml settings file at: {path}")
+            raise FileNotFoundError(f"Could not open yaml settings file at: {path.absolute()}")
 
         return yaml.safe_load(path.read_text("utf-8"))
 

--- a/app/infrastructure/db/migrations/README.md
+++ b/app/infrastructure/db/migrations/README.md
@@ -20,3 +20,9 @@ for rollback
 ```
 alembic downgrade -1
 ```
+
+### Provide config path via env var or alembic.ini
+example
+```
+CONFIG_PATH=your/path/config.yaml alembic upgrade +1
+```


### PR DESCRIPTION
I forgot to update the config mechanism in migrations. This PR fixes it.
Now migrations can setuped config via:
- env var `CONFIG_PATH` (not support .env files)
- alembic.ini var `app_config_path`